### PR TITLE
Implement node module resolution algo in VimScript

### DIFF
--- a/autoload/further/constants.vim
+++ b/autoload/further/constants.vim
@@ -1,0 +1,4 @@
+let g:further#constants#DEFAULT_ENTRY = 'index'
+let g:further#constants#BUILT_IN_EXTENSIONS = ['.js', '.json', '.mjs', '.node']
+let g:further#constants#DEFAULT_EXTENSIONS = ['.jsx', '.ts', '.tsx']
+let g:further#constants#CUSTOM_EXTENSIONS = get(g:, 'further#extensions', [])

--- a/autoload/further/resolve.vim
+++ b/autoload/further/resolve.vim
@@ -1,0 +1,38 @@
+" Implements the node module resolution algorithm.
+" See: https://nodejs.org/api/modules.html#modules_all_together
+
+func! s:IsRelativeImport(path) abort
+  let l:first_char = a:path[0]
+  return l:first_char is# '.' || l:first_char is# '/'
+endfunc
+
+" Parse a library import into two parts:
+" (given '@org/scope/path/to/export')
+" - the package name (@org/scope)
+" - the import path (path/to/export)
+func! s:ParseImport(import_path) abort
+  let l:is_org = a:import_path[0] is# '@'
+  let l:path_parts = split(a:import_path, '/')
+  let l:pkg = join(l:path_parts[0:l:is_org], '/')
+  let l:path = join(l:path_parts[l:is_org + 1:], '/')
+
+  return { 'pkg_name': l:pkg, 'path': l:path }
+endfunc
+
+" Detect and resolve different types of imports. Offloads
+" heavy lifting to logic in the resolve/ directory.
+func! further#resolve#Import(context, import) abort
+  if s:IsRelativeImport(a:import)
+    return further#resolve#relative#ImportPath(a:context, a:import)
+  endif
+
+  let l:parsed_import = s:ParseImport(a:import)
+
+  if strlen(l:parsed_import.path)
+    return further#resolve#package#WithPath(a:context, a:import)
+  endif
+
+  let l:pkg_name = l:parsed_import.pkg_name
+  let l:pkg_root = further#resolve#package#(a:context, l:pkg_name)
+  return further#resolve#package#EntryFile(l:pkg_root)
+endfunc

--- a/autoload/further/resolve.vim
+++ b/autoload/further/resolve.vim
@@ -10,7 +10,7 @@ endfunc
 " heavy lifting to logic in the resolve/ directory.
 func! further#resolve#Import(context, import) abort
   if s:IsRelativeImport(a:import)
-    return further#resolve#relative#ImportPath(a:context, a:import)
+    return further#resolve#relative#(a:context, a:import)
   endif
 
   return further#resolve#package#(a:context, a:import)

--- a/autoload/further/resolve.vim
+++ b/autoload/further/resolve.vim
@@ -6,19 +6,6 @@ func! s:IsRelativeImport(path) abort
   return l:first_char is# '.' || l:first_char is# '/'
 endfunc
 
-" Parse a library import into two parts:
-" (given '@org/scope/path/to/export')
-" - the package name (@org/scope)
-" - the import path (path/to/export)
-func! s:ParseImport(import_path) abort
-  let l:is_org = a:import_path[0] is# '@'
-  let l:path_parts = split(a:import_path, '/')
-  let l:pkg = join(l:path_parts[0:l:is_org], '/')
-  let l:path = join(l:path_parts[l:is_org + 1:], '/')
-
-  return { 'pkg_name': l:pkg, 'path': l:path }
-endfunc
-
 " Detect and resolve different types of imports. Offloads
 " heavy lifting to logic in the resolve/ directory.
 func! further#resolve#Import(context, import) abort
@@ -26,13 +13,5 @@ func! further#resolve#Import(context, import) abort
     return further#resolve#relative#ImportPath(a:context, a:import)
   endif
 
-  let l:parsed_import = s:ParseImport(a:import)
-
-  if strlen(l:parsed_import.path)
-    return further#resolve#package#WithPath(a:context, a:import)
-  endif
-
-  let l:pkg_name = l:parsed_import.pkg_name
-  let l:pkg_root = further#resolve#package#(a:context, l:pkg_name)
-  return further#resolve#package#EntryFile(l:pkg_root)
+  return further#resolve#package#(a:context, a:import)
 endfunc

--- a/autoload/further/resolve/package.vim
+++ b/autoload/further/resolve/package.vim
@@ -65,15 +65,21 @@ func! further#resolve#package#EntryFile(pkg_root) abort
   let l:pkg = s:ReadPackageJson(l:pkg_json_path)
   let l:main = s:GetMainPackageExport(l:pkg)
 
-  " No entry point specified. Try to resolve `<lib>/index`.
-  if l:main is# v:null
-    let l:file_path = simplify(a:pkg_root . '/' . s:DEFAULT_ENTRY)
-    return further#resolve#relative#File(l:file_path)
+  " Entry point was provided.
+  if l:main isnot# v:null
+    let l:entry_path = simplify(a:pkg_root . '/' . l:main)
+    let l:main_export = further#resolve#relative#(l:entry_path)
+
+    " Fall back to <lib>/index lookup if main field
+    " is invalid (yes, that's what the spec says).
+    if filereadable(l:main_export)
+      return l:main_export
+    endif
   endif
 
-  " Entry point was provided.
-  let l:entry_path = simplify(a:pkg_root . '/' . l:main)
-  return further#resolve#relative#(l:entry_path)
+  " No entry point specified. Try to resolve `<lib>/index`.
+  let l:file_path = simplify(a:pkg_root . '/' . s:DEFAULT_ENTRY)
+  return further#resolve#relative#File(l:file_path)
 endfunc
 
 " If the file exists, try to parse it as json, otherwise

--- a/autoload/further/resolve/package.vim
+++ b/autoload/further/resolve/package.vim
@@ -53,7 +53,7 @@ func! further#resolve#package#WithPath(context, pkg_path) abort
   endif
 
   let l:full_path = simplify(l:pkg_root . '/' . l:parsed_import.path)
-  return further#resolve#relative#(l:full_path)
+  return further#resolve#relative#FileOrDirectory(l:full_path)
 endfunc
 
 " Pull `main` from the package.json file. Try to be clever.
@@ -79,7 +79,7 @@ func! further#resolve#package#EntryFile(pkg_root) abort
   " Entry point was provided.
   if l:main isnot# v:null
     let l:entry_path = simplify(a:pkg_root . '/' . l:main)
-    let l:main_export = further#resolve#relative#(l:entry_path)
+    let l:main_export = further#resolve#relative#FileOrDirectory(l:entry_path)
 
     " Fall back to <lib>/index lookup if main field
     " is invalid (yes, that's what the spec says).

--- a/autoload/further/resolve/package.vim
+++ b/autoload/further/resolve/package.vim
@@ -1,5 +1,18 @@
 let s:DEFAULT_ENTRY = g:further#constants#DEFAULT_ENTRY
 
+" Parse a library import into two parts:
+" (given '@org/scope/path/to/export')
+" - the package name (@org/scope)
+" - the import path (path/to/export)
+func! s:ParseImport(import_path) abort
+  let l:is_org = a:import_path[0] is# '@'
+  let l:path_parts = split(a:import_path, '/')
+  let l:pkg = join(l:path_parts[0:l:is_org], '/')
+  let l:path = join(l:path_parts[l:is_org + 1:], '/')
+
+  return { 'pkg_name': l:pkg, 'path': l:path }
+endfunc
+
 " Scan every node_modules folder for a directory matching
 " node_modules/<package-name>
 func! s:ResolveModuleFromPath(pkg, path) abort
@@ -16,8 +29,8 @@ endfunc
 
 " Find the absolute library path, given a library name.
 " Org-scoped packages are fully supported.
-" e.g. further#resolve#package#('react')
-func! further#resolve#package#(context, pkg_name) abort
+" e.g. further#resolve#package#ByName('react')
+func! further#resolve#package#ByName(context, pkg_name) abort
   let l:paths = further#resolve#path#(a:context)
   let l:abs_path = s:ResolveModuleFromPath(a:pkg_name, l:paths)
 
@@ -31,17 +44,15 @@ endfunc
 " Resolve libary imports with a trailing import path, e.g.
 " import @org/pkg/package.json
 func! further#resolve#package#WithPath(context, pkg_path) abort
-  let l:is_org_scope = a:pkg_path[0] is# '@'
-  let l:parts = split(a:pkg_path, '/')
-  let l:pkg_name = join(l:parts[0:l:is_org_scope], '/')
-  let l:pkg_relative_path = join(l:parts[l:is_org_scope + 1:], '/')
-  let l:pkg_root = further#resolve#package#(a:context, l:pkg_name)
+  let l:parsed_import = s:ParseImport(a:pkg_path)
+  let l:pkg_name = l:parsed_import.pkg_name
+  let l:pkg_root = further#resolve#package#ByName(a:context, l:pkg_name)
 
   if l:pkg_root is# v:null
     return v:null
   endif
 
-  let l:full_path = simplify(l:pkg_root . '/' . l:pkg_relative_path)
+  let l:full_path = simplify(l:pkg_root . '/' . l:parsed_import.path)
   return further#resolve#relative#(l:full_path)
 endfunc
 
@@ -98,4 +109,19 @@ func! s:ReadPackageJson(pkg_json_path) abort
   endif
 
   return v:null
+endfunc
+
+" Split between package#ByName and package#WithPath.
+func! further#resolve#package#(context, import) abort
+  let l:parsed_import = s:ParseImport(a:import)
+
+  " import 'package/src/file'
+  if strlen(l:parsed_import.path)
+    return further#resolve#package#WithPath(a:context, a:import)
+  endif
+
+  " import 'package'
+  let l:pkg_name = l:parsed_import.pkg_name
+  let l:pkg_root = further#resolve#package#ByName(a:context, l:pkg_name)
+  return further#resolve#package#EntryFile(l:pkg_root)
 endfunc

--- a/autoload/further/resolve/package.vim
+++ b/autoload/further/resolve/package.vim
@@ -1,0 +1,95 @@
+let s:DEFAULT_ENTRY = g:further#constants#DEFAULT_ENTRY
+
+" Scan every node_modules folder for a directory matching
+" node_modules/<package-name>
+func! s:ResolveModuleFromPath(pkg, path) abort
+  for l:module_directory in a:path
+    let l:pkg_path = l:module_directory . '/' . a:pkg
+
+    if isdirectory(l:pkg_path)
+      return l:pkg_path
+    endif
+  endfor
+
+  return v:null
+endfunc
+
+" Find the absolute library path, given a library name.
+" Org-scoped packages are fully supported.
+" e.g. further#resolve#package#('react')
+func! further#resolve#package#(context, pkg_name) abort
+  let l:paths = further#resolve#path#(a:context)
+  let l:abs_path = s:ResolveModuleFromPath(a:pkg_name, l:paths)
+
+  if l:abs_path isnot# v:null
+    return l:abs_path
+  endif
+
+  return v:null
+endfunc
+
+" Resolve libary imports with a trailing import path, e.g.
+" import @org/pkg/package.json
+func! further#resolve#package#WithPath(context, pkg_path) abort
+  let l:is_org_scope = a:pkg_path[0] is# '@'
+  let l:parts = split(a:pkg_path, '/')
+  let l:pkg_name = join(l:parts[0:l:is_org_scope], '/')
+  let l:pkg_relative_path = join(l:parts[l:is_org_scope + 1:], '/')
+  let l:pkg_root = further#resolve#package#(a:context, l:pkg_name)
+
+  if l:pkg_root is# v:null
+    return v:null
+  endif
+
+  let l:full_path = simplify(l:pkg_root . '/' . l:pkg_relative_path)
+  return further#resolve#relative#(l:full_path)
+endfunc
+
+" Pull `main` from the package.json file. Try to be clever.
+func! s:GetMainPackageExport(pkg_json) abort
+  if a:pkg_json is# v:null | return v:null | endif
+
+  " Try several entry point conventions.
+  let l:main = get(a:pkg_json, 'main', s:DEFAULT_ENTRY)
+  let l:jsnext = get(a:pkg_json, 'jsnext:main', l:main)
+  let l:module = get(a:pkg_json, 'module', l:jsnext)
+
+  let l:prefer_module = get(g:, 'further#prefer_module', v:false)
+  return l:prefer_module ? l:module : l:main
+endfunc
+
+" Given a package directory, find the main export file.
+" If the file doesn't exist or can't be inferred, return null.
+func! further#resolve#package#EntryFile(pkg_root) abort
+  let l:pkg_json_path = simplify(a:pkg_root . '/package.json')
+  let l:pkg = s:ReadPackageJson(l:pkg_json_path)
+  let l:main = s:GetMainPackageExport(l:pkg)
+
+  " No entry point specified. Try to resolve `<lib>/index`.
+  if l:main is# v:null
+    let l:file_path = simplify(a:pkg_root . '/' . s:DEFAULT_ENTRY)
+    return further#resolve#relative#File(l:file_path)
+  endif
+
+  " Entry point was provided.
+  let l:entry_path = simplify(a:pkg_root . '/' . l:main)
+  return further#resolve#relative#(l:entry_path)
+endfunc
+
+" If the file exists, try to parse it as json, otherwise
+" return null. Fail silently if the json is invalid (e.g. json5).
+func! s:ReadPackageJson(pkg_json_path) abort
+  if !filereadable(a:pkg_json_path)
+    return v:null
+  endif
+
+  let l:contents = readfile(a:pkg_json_path)
+  let l:contents = join(l:contents, "\n")
+
+  silent! let l:pkg_json = json_decode(l:contents)
+  if l:pkg_json isnot# 0
+    return l:pkg_json
+  endif
+
+  return v:null
+endfunc

--- a/autoload/further/resolve/path.vim
+++ b/autoload/further/resolve/path.vim
@@ -1,3 +1,6 @@
+" Support for global module paths (mostly deprecated). Missing
+" the `process.config.node_prefix` path since it seems to only
+" be available inside Node's runtime as a compilation artifact.
 let s:node_path_delimiter = has('win32') ? ';' : ':'
 let s:NODE_PATH = split($NODE_PATH, s:node_path_delimiter)
 let s:GLOBAL_PATHS = s:NODE_PATH + [

--- a/autoload/further/resolve/path.vim
+++ b/autoload/further/resolve/path.vim
@@ -8,6 +8,14 @@ let s:GLOBAL_PATHS = s:NODE_PATH + [
       \   expand('~/.node_libraries'),
       \ ]
 
+func! s:EnsureAbsolutePath(path) abort
+  if a:path[0] is# '/'
+    return a:path
+  endif
+
+  return fnamemodify(a:path, ':p')
+endfunc
+
 " Given a file path, locate every node_modules
 " folder it's capable of drawing from.
 " `abort` intentionally omitted. `:lcd` must be reset.
@@ -21,6 +29,7 @@ func! further#resolve#path#(file_path)
 
   call execute('lcd ' . fnameescape(l:dir))
   let l:module_folders = finddir('node_modules', ';', -1)
+  call map(l:module_folders, 's:EnsureAbsolutePath(v:val)')
   lcd -
 
   return l:module_folders + s:GLOBAL_PATHS

--- a/autoload/further/resolve/path.vim
+++ b/autoload/further/resolve/path.vim
@@ -1,3 +1,10 @@
+let s:node_path_delimiter = has('win32') ? ';' : ':'
+let s:NODE_PATH = split($NODE_PATH, s:node_path_delimiter)
+let s:GLOBAL_PATHS = s:NODE_PATH + [
+      \   expand('~/.node_modules'),
+      \   expand('~/.node_libraries'),
+      \ ]
+
 " Given a file path, locate every node_modules
 " folder it's capable of drawing from.
 " `abort` intentionally omitted. `:lcd` must be reset.
@@ -13,5 +20,5 @@ func! further#resolve#path#(file_path)
   let l:module_folders = finddir('node_modules', ';', -1)
   lcd -
 
-  return l:module_folders
+  return l:module_folders + s:GLOBAL_PATHS
 endfunc

--- a/autoload/further/resolve/path.vim
+++ b/autoload/further/resolve/path.vim
@@ -1,0 +1,17 @@
+" Given a file path, locate every node_modules
+" folder it's capable of drawing from.
+" `abort` intentionally omitted. `:lcd` must be reset.
+func! further#resolve#path#(file_path)
+  let l:module_folders = []
+  let l:dir = a:file_path
+
+  if !isdirectory(l:dir)
+    let l:dir = fnamemodify(l:dir, ':h')
+  endif
+
+  call execute('lcd ' . fnameescape(l:dir))
+  let l:module_folders = finddir('node_modules', ';', -1)
+  lcd -
+
+  return l:module_folders
+endfunc

--- a/autoload/further/resolve/relative.vim
+++ b/autoload/further/resolve/relative.vim
@@ -24,10 +24,13 @@ func! further#resolve#relative#File(path) abort
   return v:null
 endfunc
 
+func! s:IsAbsolute(import) abort
+  return a:import[0] is# '/'
+endfunc
 
 " Resolve the path as either a file or a directory.
-func! further#resolve#relative#(file_or_directory) abort
-  let l:file = a:file_or_directory
+func! further#resolve#relative#FileOrDirectory(path) abort
+  let l:file = a:path
   if isdirectory(l:file)
     let l:file = simplify(l:file . '/' . s:DEFAULT_ENTRY)
   endif
@@ -37,11 +40,11 @@ endfunc
 
 " Resolve absolute and relative import paths. Context path
 " should be parent directory of the file doing the import.
-func! further#resolve#relative#ImportPath(context, import) abort
-  if a:import[0] is# '/'
-    return further#resolve#relative#File(a:import)
+func! further#resolve#relative#(context, import) abort
+  if s:IsAbsolute(a:import)
+    return further#resolve#relative#FileOrDirectory(a:import)
   endif
 
   let l:import_path = simplify(a:context . '/' . a:import)
-  return further#resolve#relative#File(l:import_path)
+  return further#resolve#relative#FileOrDirectory(l:import_path)
 endfunc

--- a/autoload/further/resolve/relative.vim
+++ b/autoload/further/resolve/relative.vim
@@ -1,0 +1,47 @@
+let s:DEFAULT_ENTRY = g:further#constants#DEFAULT_ENTRY
+let s:CUSTOM_EXTENSIONS = g:further#constants#CUSTOM_EXTENSIONS
+let s:BUILT_IN_EXTENSIONS = g:further#constants#BUILT_IN_EXTENSIONS
+let s:DEFAULT_EXTENSIONS = g:further#constants#DEFAULT_EXTENSIONS
+
+" If the file exists with any whitelisted extension,
+" return the path. Otherwise return null.
+func! further#resolve#relative#File(path) abort
+  " Always check for an exact match first.
+  let l:extensions = ['']
+        \ + s:BUILT_IN_EXTENSIONS
+        \ + s:DEFAULT_EXTENSIONS
+        \ + s:CUSTOM_EXTENSIONS
+
+  " Return the first result that points to a readable file.
+  for l:extension in l:extensions
+    let l:file_path = a:path . l:extension
+
+    if filereadable(l:file_path)
+      return l:file_path
+    endif
+  endfor
+
+  return v:null
+endfunc
+
+
+" Resolve the path as either a file or a directory.
+func! further#resolve#relative#(file_or_directory) abort
+  let l:file = a:file_or_directory
+  if isdirectory(l:file)
+    let l:file = simplify(l:file . '/' . s:DEFAULT_ENTRY)
+  endif
+
+  return further#resolve#relative#File(l:file)
+endfunc
+
+" Resolve absolute and relative import paths. Context path
+" should be parent directory of the file doing the import.
+func! further#resolve#relative#ImportPath(context, import) abort
+  if a:import[0] is# '/'
+    return further#resolve#relative#File(a:import)
+  endif
+
+  let l:import_path = simplify(a:context . '/' . a:import)
+  return further#resolve#relative#File(l:import_path)
+endfunc

--- a/autoload/further/resolve/relative.vim
+++ b/autoload/further/resolve/relative.vim
@@ -30,12 +30,20 @@ endfunc
 
 " Resolve the path as either a file or a directory.
 func! further#resolve#relative#FileOrDirectory(path) abort
-  let l:file = a:path
-  if isdirectory(l:file)
-    let l:file = simplify(l:file . '/' . s:DEFAULT_ENTRY)
+  let l:file_path = further#resolve#relative#File(a:path)
+
+  " Check for files before directories.
+  if l:file_path isnot# v:null
+    return l:file_path
   endif
 
-  return further#resolve#relative#File(l:file)
+  " Not a file. Maybe it's a directory?
+  if isdirectory(a:path)
+    let l:file = simplify(a:path . '/' . s:DEFAULT_ENTRY)
+    return further#resolve#relative#File(l:file)
+  endif
+
+  return v:null
 endfunc
 
 " Resolve absolute and relative import paths. Context path


### PR DESCRIPTION
Most of node's module resolution algorithm is now implemented in Further
with the exception of a few small items:
- ~No support for $NODE_PATH (fix coming soon)~ ✅ 
- ~`pkg.main` fallback isn't fully implemented (next on agenda)~ ✅ 

This has several advantages, but the main advantage is first-class support
for more extensions, like `.tsx` and `.mjs`. If the extension of choice
isn't listed you can extend it with `further#extensions`.

Documentation coming later. I'm waaaay too tired to write it now.