### PR TITLE
Consider package.json for relative directories

### DIFF
--- a/autoload/further/resolve/module.vim
+++ b/autoload/further/resolve/module.vim
@@ -1,0 +1,62 @@
+" High-level:
+" If $DIR/package.json then
+"   load file($DIR + pkg.main) or
+"   load file($DIR + pkg.main + 'index')
+" else load index($DIR)
+
+let s:DEFAULT_ENTRY = g:further#constants#DEFAULT_ENTRY
+
+" If the file exists, try to parse it as json, otherwise
+" return null. Fail silently if the json is invalid (e.g. json5).
+func! further#resolve#module#PackageJson(directory) abort
+  let l:pkg_json_path = simplify(a:directory . '/package.json')
+  if !filereadable(l:pkg_json_path)
+    return v:null
+  endif
+
+  let l:contents = readfile(l:pkg_json_path)
+  let l:contents = join(l:contents, "\n")
+
+  silent! let l:pkg_json = json_decode(l:contents)
+  if l:pkg_json isnot# 0
+    return l:pkg_json
+  endif
+
+  return v:null
+endfunc
+
+" Pull `main` from the package.json file. Try to be clever.
+func! s:GetMainPackageExport(pkg_json) abort
+  if a:pkg_json is# v:null | return v:null | endif
+
+  " Try several entry point conventions.
+  let l:main = get(a:pkg_json, 'main', s:DEFAULT_ENTRY)
+  let l:jsnext = get(a:pkg_json, 'jsnext:main', l:main)
+  let l:module = get(a:pkg_json, 'module', l:jsnext)
+
+  let l:prefer_module = get(g:, 'further#prefer_modules', v:false)
+  return l:prefer_module ? l:module : l:main
+endfunc
+
+" Given a directory, find the main export file.
+" If the file doesn't exist or can't be inferred, return null.
+func! further#resolve#module#EntryPoint(pkg_root) abort
+  let l:pkg = further#resolve#module#PackageJson(a:pkg_root)
+  let l:main = s:GetMainPackageExport(l:pkg)
+
+  " Entry point was provided.
+  if l:main isnot# v:null
+    let l:entry_path = simplify(a:pkg_root . '/' . l:main)
+    let l:main_export = further#resolve#relative#FileOrIndex(l:entry_path)
+
+    " Fall back to <lib>/index lookup if main field
+    " is invalid (yes, that's what the spec says).
+    if filereadable(l:main_export)
+      return l:main_export
+    endif
+  endif
+
+  " No entry point specified. Try to resolve `<lib>/index`.
+  let l:file_path = simplify(a:pkg_root . '/' . s:DEFAULT_ENTRY)
+  return further#resolve#relative#File(l:file_path)
+endfunc

--- a/autoload/further/resolve/module.vim
+++ b/autoload/further/resolve/module.vim
@@ -1,8 +1,8 @@
 " High-level:
-" If $DIR/package.json then
+" if $DIR/package.json then
 "   load file($DIR + pkg.main) or
-"   load file($DIR + pkg.main + 'index')
-" else load index($DIR)
+"   load file($DIR + pkg.main + '/index')
+" else load file($DIR + '/index')
 
 let s:DEFAULT_ENTRY = g:further#constants#DEFAULT_ENTRY
 


### PR DESCRIPTION
This PR fixes two problems.

## First problem: always* consider `package.json`
Further only considers `package.json` when the module path was found through `node_modules`. According to the spec, it should consider package.json for (almost) all directories.

```
package1/
  index.js => import '../package2
package2/
  package.json => main: ./lib.js
  lib.js
```

On master, this fails with "can't find module `../package2`." It should resolve `lib.js`.

*Exception: Don't consider `package.json` if you just came from a `package.json`.
```
node_modules
  library/
    package.json => main: ./nested-dir
    nested-dir/
      package.json => main: ./decoy
      index.js
      decoy.js
```

This should resolve to `nested-dir/index.js`, even though `nested-dir` has a `package.json`.

## Second problem: `node_modules/node_modules`
Per [the spec](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders) if you're editing a file at `node_modules/some-file.js` like a terrorist and for some ungodly reason you have a nested `node_modules` folder, well... I have many questions, but the spec says the `node_modules/node_modules` path shouldn't be checked when resolving libraries.

That's a pretty specific exception and it shows up multiple times in the docs. I'm sure there's a great story behind it.

Fixes #12 